### PR TITLE
Add AMI transcript ingestion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-README
+# Project Transcript Preparation
+
+This repository includes utilities for preparing AMI-style meeting transcripts for downstream experiments.
+
+## Raw transcripts
+
+Place the eight AMI transcript files in `data/transcripts/` using the following filenames:
+
+- `EN2001a.txt`
+- `EN2001b.txt`
+- `EN2001d.txt`
+- `EN2001e.txt`
+- `EN2002a.txt`
+- `EN2002b.txt`
+- `EN2002c.txt`
+- `EN2002d.txt`
+
+Sample placeholder transcripts are already provided in the repository so you can run the pipeline immediately.
+
+## Preparing structured JSON
+
+The ingestion script normalizes speaker turns and writes structured JSON files to the specified output directory. Run it with:
+
+```bash
+python -m src.data.prepare_transcripts --input data/transcripts --output data/processed
+```
+
+The command reads every `.txt` transcript in the input directory and writes a corresponding `.json` file into `data/processed/`. Each invocation prints the location of the files it writes so you can quickly confirm the output.
+
+## Output format
+
+Every generated JSON file follows this structure:
+
+```json
+{
+  "meeting_id": "EN2001a",
+  "turns": [
+    {
+      "speaker": "CHAIR",
+      "utterance": "Good morning everyone, let's review yesterday's notes.",
+      "start_time": null,
+      "end_time": null,
+      "annotations": {
+        "tasks": [],
+        "actions": []
+      }
+    }
+  ]
+}
+```
+
+- `meeting_id` is the stem of the transcript filename.
+- `turns` is an ordered list of normalized speaker turns.
+- `speaker` is uppercased and spaces are replaced with underscores so that each label is consistent across meetings.
+- `utterance` contains the normalized text for that speaker turn. If a transcript line extends over multiple lines without a new speaker tag, the script concatenates it to the previous turn.
+- `start_time` and `end_time` fields are included for future timestamp enrichment and currently set to `null`.
+- `annotations.tasks` and `annotations.actions` are placeholders for future task labeling work.
+
+Adjust the input or output paths with the `--input` and `--output` arguments when integrating with other pipelines.

--- a/data/transcripts/EN2001a.txt
+++ b/data/transcripts/EN2001a.txt
@@ -1,0 +1,5 @@
+Chair: Good morning everyone, let's review yesterday's notes.
+Scribe: I've summarized the key decisions from the kickoff.
+Engineer: I'd like to clarify the timeline before we proceed.
+Designer: I have sketches ready for the updated interface.
+Chair: Perfect, let's walk through each topic in order.

--- a/data/transcripts/EN2001b.txt
+++ b/data/transcripts/EN2001b.txt
@@ -1,0 +1,5 @@
+Chair: Today we need to finalize the speaker assignments.
+Engineer: I'll take the technical walkthrough in the second half.
+Designer: I can support with visuals and live demos.
+Scribe: I'll capture action items and open questions.
+Chair: Great, please coordinate rehearsal times afterwards.

--- a/data/transcripts/EN2001d.txt
+++ b/data/transcripts/EN2001d.txt
@@ -1,0 +1,5 @@
+Chair: Let's revisit the risks identified in the last session.
+Engineer: Supply delays remain our biggest concern right now.
+Designer: We could adjust the rollout to prioritize the core modules.
+Scribe: I'll flag that as a proposed mitigation in the notes.
+Chair: Please quantify the impact for the next checkpoint report.

--- a/data/transcripts/EN2001e.txt
+++ b/data/transcripts/EN2001e.txt
@@ -1,0 +1,5 @@
+Chair: Welcome back, let's track progress on assigned actions.
+Engineer: The prototype integration completed successfully.
+Designer: User testing highlights usability wins and a few gaps.
+Scribe: I'll mark the open issues for follow-up owners.
+Chair: Excellent, let's set deadlines for each remaining task.

--- a/data/transcripts/EN2002a.txt
+++ b/data/transcripts/EN2002a.txt
@@ -1,0 +1,5 @@
+Chair: Our agenda covers budget, staffing, and communication plans.
+Engineer: The hardware quote increased due to supplier changes.
+Designer: We may need to simplify the feature set to stay on budget.
+Scribe: Recording these trade-offs so we can brief the sponsors.
+Chair: Let's evaluate alternatives and prepare a recommendation.

--- a/data/transcripts/EN2002b.txt
+++ b/data/transcripts/EN2002b.txt
@@ -1,0 +1,5 @@
+Chair: We'll start with updates from the technical sub-team.
+Engineer: Firmware testing uncovered two blocking defects.
+Designer: The interface mock-ups were well received in the pilot.
+Scribe: Action items noted for defect fixes and usability tweaks.
+Chair: Keep stakeholders informed as we resolve these items.

--- a/data/transcripts/EN2002c.txt
+++ b/data/transcripts/EN2002c.txt
@@ -1,0 +1,5 @@
+Chair: Let's dedicate this session to preparing the client demo.
+Designer: I've staged the screens in the order we'll present them.
+Engineer: I'll run through the data pipeline to show end-to-end flow.
+Scribe: Capturing timing cues so we stay within the allotted slot.
+Chair: Remember to emphasize how feedback has been incorporated.

--- a/data/transcripts/EN2002d.txt
+++ b/data/transcripts/EN2002d.txt
@@ -1,0 +1,5 @@
+Chair: Final meeting before handoff, let's close outstanding items.
+Engineer: Testing is green after rerunning the regression suite.
+Designer: The latest content deck reflects all requested edits.
+Scribe: Action log shows only one follow-up on training materials.
+Chair: Assign that to the enablement lead and confirm completion.

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data preparation utilities for transcript ingestion."""

--- a/src/data/prepare_transcripts.py
+++ b/src/data/prepare_transcripts.py
@@ -1,0 +1,130 @@
+"""Utilities for converting raw AMI-style transcripts into structured JSON.
+
+This module reads text transcripts where each speaker turn is formatted as
+```
+Speaker: Utterance text
+```
+and normalizes the turns into a machine-readable representation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+SPEAKER_PATTERN = re.compile(r"^(?P<speaker>[^:]+):\s*(?P<text>.*)$")
+
+
+@dataclass
+class Turn:
+    """Representation of a normalized speaker turn."""
+
+    speaker: str
+    utterance: str
+    start_time: Optional[float] = None
+    end_time: Optional[float] = None
+    annotations: Optional[dict] = None
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        # Ensure annotations defaults to the expected shape.
+        data.setdefault("annotations", {"tasks": [], "actions": []})
+        if data["annotations"] is None:
+            data["annotations"] = {"tasks": [], "actions": []}
+        return data
+
+
+def normalize_speaker(raw: str) -> str:
+    """Normalize speaker labels into a consistent identifier."""
+
+    normalized = re.sub(r"\s+", " ", raw.strip())
+    # Uppercase for consistency and replace spaces with underscores.
+    return normalized.upper().replace(" ", "_")
+
+
+def parse_transcript(text: Iterable[str]) -> List[Turn]:
+    """Parse a transcript into normalized speaker turns."""
+
+    turns: List[Turn] = []
+    current_turn: Optional[Turn] = None
+
+    for raw_line in text:
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        match = SPEAKER_PATTERN.match(line)
+        if match:
+            speaker = normalize_speaker(match.group("speaker"))
+            utterance = match.group("text").strip()
+            current_turn = Turn(
+                speaker=speaker,
+                utterance=utterance,
+                annotations={"tasks": [], "actions": []},
+            )
+            turns.append(current_turn)
+        elif current_turn is not None:
+            # Continuation of the previous speaker's utterance.
+            current_turn.utterance = f"{current_turn.utterance} {line}".strip()
+        else:
+            # Line before any speaker tag; treat as narrator.
+            current_turn = Turn(
+                speaker="NARRATOR",
+                utterance=line,
+                annotations={"tasks": [], "actions": []},
+            )
+            turns.append(current_turn)
+
+    return turns
+
+
+def prepare_transcripts(input_dir: Path, output_dir: Path) -> None:
+    """Convert raw transcripts in ``input_dir`` into JSON files in ``output_dir``."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for transcript_path in sorted(input_dir.glob("*.txt")):
+        with transcript_path.open("r", encoding="utf-8") as handle:
+            turns = parse_transcript(handle)
+
+        meeting_id = transcript_path.stem
+        output_payload = {
+            "meeting_id": meeting_id,
+            "turns": [turn.to_dict() for turn in turns],
+        }
+
+        destination = output_dir / f"{meeting_id}.json"
+        with destination.open("w", encoding="utf-8") as sink:
+            json.dump(output_payload, sink, ensure_ascii=False, indent=2)
+
+        print(f"Wrote {destination}")
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=Path("data/transcripts"),
+        help="Directory containing raw transcript .txt files.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/processed"),
+        help="Directory to write normalized JSON transcripts.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.input.exists():
+        raise FileNotFoundError(f"Input directory not found: {args.input}")
+
+    prepare_transcripts(args.input, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add placeholder AMI transcript files for the initial meetings
- implement a transcript preparation script that normalizes speaker turns and writes JSON output
- document how to run the ingestion workflow and the shape of the generated files

## Testing
- python -m src.data.prepare_transcripts --input data/transcripts --output data/processed

------
https://chatgpt.com/codex/tasks/task_e_68d8162722d8832d8a5ae325b658ddf7